### PR TITLE
Merge feature/#42027-Handle-SpacesInFileNames into develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cine-cleaner",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An application to add redactions to videos.",
   "main": "./out/main/index.js",
   "author": "The ABR",

--- a/src/main/ipc/export-video.ts
+++ b/src/main/ipc/export-video.ts
@@ -52,13 +52,13 @@ export const exportVideo: Parameters<typeof ipcMain.handle>[1] = async (
     // https://github.com/kribblo/node-ffmpeg-installer/blob/master/README.md#wrong-path-under-electron-with-asar-enabled
     ffmpeg.path.replace('app.asar', 'app.asar.unpacked'),
     '-i', // input file
-    inputPath,
+    `"${inputPath}"`, // Use double quotes to handle spaces in path
     '-vf', // video filter
     `"${videoFilter}"`, // Use double quotes to handle spaces in filter
     '-c:a', // copy audio codec
     'copy',
     '-y', // Overwrite output file if it exists
-    outputPath,
+    `"${outputPath}"`, // Use double quotes to handle spaces in path
   ];
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
When testing the cine-cleaner it was found that file exports would not work if the file name (import or export) had a space in it.

This is because the way to params are currently passed to ffmpeg command results in something akin to
```bash
ffmpeg -i some video path.mp4 -vf ...
```

By adding quotes around the input path as a string literal:
```bash
ffmpeg -i "some video path.mp4" -vf ...
```

And now we can have spaces in the video names.