### PR TITLE
Merge feature/#42027-MakeRedactionsScaleWhenResizingVideo in develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cine-cleaner",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "An application to add redactions to videos.",
   "main": "./out/main/index.js",
   "author": "The ABR",
@@ -24,6 +24,7 @@
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^4.0.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
+    "@solid-primitives/resize-observer": "^2.1.0",
     "electron-updater": "^6.3.9",
     "lucide-solid": "^0.487.0",
     "tailwindcss": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@ffmpeg-installer/ffmpeg':
         specifier: ^1.1.0
         version: 1.1.0
+      '@solid-primitives/resize-observer':
+        specifier: ^2.1.0
+        version: 2.1.0(solid-js@1.9.5)
       electron-updater:
         specifier: ^6.3.9
         version: 6.6.2
@@ -649,6 +652,31 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@solid-primitives/event-listener@2.4.0':
+    resolution: {integrity: sha512-TSfR1PNTfojFEYGSxSMCnUhXsaYWBo4p+cm73QmWODa9YnaQAk6PB7VjzG2bOT2D817VlvuOqTj0Qdq+MZrdGg==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/resize-observer@2.1.0':
+    resolution: {integrity: sha512-tO9MDAc2pNjpcRd5B8LWbiR1qzIgvGZ5BtTuO98N7CLwd+fnuyGwtlQtJpz5hcLcTnoawpQYLpiRGNgaYW+YzQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/rootless@1.5.0':
+    resolution: {integrity: sha512-YJ+EveQeDv9DLqfDKfsPAAGy2x3vBruoD23yn+nD2dT84QjoBxWT1T0qA0TMFjek6/xuN3flqnHtQ4r++4zdjg==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/static-store@0.1.0':
+    resolution: {integrity: sha512-6Coau0Kv/dF83UQpbBzc+gnJafOQAPe2jCbB4jmTK5UocsR5cWmFBVRm3kin+nZFVaO4WkuELw0cKANWgTVh8Q==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/utils@6.3.0':
+    resolution: {integrity: sha512-e7hTlJ1Ywh2+g/Qug+n4L1mpfxsikoIS4/sHE2EK9WatQt8UJqop/vE6bsLnXlU1xuhb/jo94Ah5Y27rd4wP7A==}
+    peerDependencies:
+      solid-js: ^1.6.12
 
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -3170,6 +3198,33 @@ snapshots:
     optional: true
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@solid-primitives/event-listener@2.4.0(solid-js@1.9.5)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.0(solid-js@1.9.5)
+      solid-js: 1.9.5
+
+  '@solid-primitives/resize-observer@2.1.0(solid-js@1.9.5)':
+    dependencies:
+      '@solid-primitives/event-listener': 2.4.0(solid-js@1.9.5)
+      '@solid-primitives/rootless': 1.5.0(solid-js@1.9.5)
+      '@solid-primitives/static-store': 0.1.0(solid-js@1.9.5)
+      '@solid-primitives/utils': 6.3.0(solid-js@1.9.5)
+      solid-js: 1.9.5
+
+  '@solid-primitives/rootless@1.5.0(solid-js@1.9.5)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.0(solid-js@1.9.5)
+      solid-js: 1.9.5
+
+  '@solid-primitives/static-store@0.1.0(solid-js@1.9.5)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.0(solid-js@1.9.5)
+      solid-js: 1.9.5
+
+  '@solid-primitives/utils@6.3.0(solid-js@1.9.5)':
+    dependencies:
+      solid-js: 1.9.5
 
   '@szmarczak/http-timer@4.0.6':
     dependencies:

--- a/src/renderer/src/components/Video.tsx
+++ b/src/renderer/src/components/Video.tsx
@@ -1,0 +1,128 @@
+import { useVideoData } from '@renderer/context/useVideoData';
+import { Actions } from '@renderer/store';
+import { createResizeObserver } from '@solid-primitives/resize-observer';
+import {
+  Component,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  Show,
+} from 'solid-js';
+import { Redaction } from './Redaction';
+import { RedactionMover } from './RedactionMover';
+import { RedactionResizer } from './RedactionResizer';
+import { Pause, Play } from 'lucide-solid';
+import { ExportVideoButton } from './ExportVideoButton';
+
+export const Video: Component = () => {
+  const [videoState, dispatch] = useVideoData();
+  const [isPlaying, setIsPlaying] = createSignal(false);
+  let videoRef!: HTMLVideoElement;
+
+  const togglePlay = (): void => {
+    if (isPlaying()) {
+      videoRef.pause();
+    } else {
+      videoRef.play();
+    }
+    setIsPlaying(playing => !playing);
+  };
+
+  const onMouseLeave = (): void => {
+    dispatch({ type: Actions.MouseLeave });
+  };
+
+  const startPlaying = (): void => {
+    setIsPlaying(true);
+  };
+  const stopPlaying = (): void => {
+    setIsPlaying(false);
+  };
+
+  onMount(() => {
+    videoRef.addEventListener('play', startPlaying);
+    videoRef.addEventListener('pause', stopPlaying);
+    videoRef.addEventListener('ended', stopPlaying);
+    window.addEventListener('mouseleave', onMouseLeave);
+
+    if (videoState.videoDimensions == null) {
+      createResizeObserver(videoRef, ({ width, height }, el) => {
+        if (videoRef === el) {
+          dispatch({
+            type: Actions.ResizeVideo,
+            payload: { width, height },
+          });
+        }
+      });
+      dispatch({
+        type: Actions.SetVideoDimensions,
+        payload: {
+          width: videoRef.clientWidth,
+          height: videoRef.clientHeight,
+        },
+      });
+    }
+  });
+
+  onCleanup(() => {
+    videoRef.removeEventListener('play', startPlaying);
+    videoRef.removeEventListener('pause', stopPlaying);
+    videoRef.removeEventListener('ended', stopPlaying);
+    window.removeEventListener('mouseleave', onMouseLeave);
+  });
+
+  return (
+    <>
+      <div
+        onMouseLeave={onMouseLeave}
+        class="flex-1 relative min-h-0 max-h-full h-full"
+      >
+        <video ref={videoRef!} class="pointer-events-none h-auto max-h-full">
+          <source src={videoState.videoSrc!} type="video/mp4" />
+          Your browser does not support the video tag.
+        </video>
+        <div
+          class="absolute top-0 left-0"
+          style={{
+            width: videoRef.clientWidth + 'px',
+            height: videoRef.clientHeight + 'px',
+          }}
+        >
+          <For each={videoState.redactions}>
+            {redaction => (
+              <Redaction redaction={redaction}>
+                <Show when={!videoState.previewMode}>
+                  <RedactionMover
+                    redaction={redaction}
+                    maxCoords={{
+                      x: videoRef.clientWidth,
+                      y: videoRef.clientHeight,
+                    }}
+                  />
+                  <RedactionResizer redaction={redaction} />
+                </Show>
+              </Redaction>
+            )}
+          </For>
+        </div>
+      </div>
+      <div class="flex flex-0 justify-between items-center gap-4">
+        <button
+          class="px-4 py-2 bg-blue-500 w-[105px] text-white rounded-lg hover:bg-blue-600 transition-colors flex items-center gap-2"
+          onClick={togglePlay}
+        >
+          {isPlaying() ? <Pause class="w-4 h-4" /> : <Play class="w-4 h-4" />}
+          {isPlaying() ? 'Pause' : 'Play'}
+        </button>
+        <button
+          class="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors flex items-center gap-2"
+          onClick={() => dispatch({ type: Actions.AddRedaction })}
+        >
+          Add Redaction
+        </button>
+        <ExportVideoButton videoRef={videoRef} />
+      </div>
+    </>
+  );
+};

--- a/src/renderer/src/components/VideoEditor.tsx
+++ b/src/renderer/src/components/VideoEditor.tsx
@@ -1,67 +1,18 @@
-import {
-  createSignal,
-  Show,
-  Component,
-  For,
-  createEffect,
-  onCleanup,
-} from 'solid-js';
-import { Redaction } from './Redaction';
-import { Pause, Play, Upload } from 'lucide-solid';
-import { RedactionMover } from './RedactionMover';
-import { RedactionResizer } from './RedactionResizer';
-import { ExportVideoButton } from './ExportVideoButton';
+import { Show, Component } from 'solid-js';
+import { Upload } from 'lucide-solid';
+
 import { useVideoData } from '@renderer/context/useVideoData';
 import { Actions } from '@renderer/store';
+import { Video } from './Video';
 
 const VideoEditor: Component = () => {
-  const [isPlaying, setIsPlaying] = createSignal(false);
   const [videoState, dispatch] = useVideoData();
 
-  let videoRef!: HTMLVideoElement;
-
   const handleFileUpload = async (): Promise<void> => {
-    console.log('handleFileUpload');
     const filePath = await window.api.selectVideo(); // Call Electron API
     if (!filePath) return;
     dispatch({ type: Actions.SetVideoSrc, payload: filePath });
   };
-
-  const togglePlay = (): void => {
-    if (isPlaying()) {
-      videoRef.pause();
-    } else {
-      videoRef.play();
-    }
-    setIsPlaying(!isPlaying());
-  };
-
-  const onMouseLeave = (): void => {
-    dispatch({ type: Actions.MouseLeave });
-  };
-
-  const startPlaying = (): void => {
-    setIsPlaying(true);
-  };
-  const stopPlaying = (): void => {
-    setIsPlaying(false);
-  };
-  createEffect(() => {
-    if (videoRef) {
-      videoRef.addEventListener('play', startPlaying);
-      videoRef.addEventListener('pause', stopPlaying);
-      videoRef.addEventListener('ended', stopPlaying);
-    }
-    window.addEventListener('mouseleave', onMouseLeave);
-    onCleanup(() => {
-      if (videoRef) {
-        videoRef.removeEventListener('play', startPlaying);
-        videoRef.removeEventListener('pause', stopPlaying);
-        videoRef.removeEventListener('ended', stopPlaying);
-      }
-      window.removeEventListener('mouseleave', onMouseLeave);
-    });
-  });
 
   return (
     <div class="h-screen bg-slate-100 flex flex-col items-center justify-center p-8">
@@ -101,62 +52,7 @@ const VideoEditor: Component = () => {
             </>
           }
         >
-          <div
-            onMouseLeave={onMouseLeave}
-            class="flex-1 relative min-h-0 max-h-full h-full"
-          >
-            <video
-              ref={videoRef!}
-              class="pointer-events-none h-auto max-h-full"
-            >
-              <source src={videoState.videoSrc!} type="video/mp4" />
-              Your browser does not support the video tag.
-            </video>
-            <div
-              class="absolute top-0 left-0"
-              style={{
-                width: videoRef.clientWidth + 'px',
-                height: videoRef.clientHeight + 'px',
-              }}
-            >
-              <For each={videoState.redactions}>
-                {redaction => (
-                  <Redaction redaction={redaction}>
-                    <Show when={!videoState.previewMode}>
-                      <RedactionMover
-                        redaction={redaction}
-                        maxCoords={{
-                          x: videoRef.clientWidth,
-                          y: videoRef.clientHeight,
-                        }}
-                      />
-                      <RedactionResizer redaction={redaction} />
-                    </Show>
-                  </Redaction>
-                )}
-              </For>
-            </div>
-          </div>
-          <div class="flex flex-0 justify-between items-center gap-4">
-            <button
-              class="px-4 py-2 bg-blue-500 w-[105px] text-white rounded-lg hover:bg-blue-600 transition-colors flex items-center gap-2"
-              onClick={togglePlay}
-            >
-              {isPlaying() ? (
-                <Pause class="w-4 h-4" />
-              ) : (
-                <Play class="w-4 h-4" />
-              )}
-              {isPlaying() ? 'Pause' : 'Play'}
-            </button>
-            <button
-              class="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors flex items-center gap-2"
-              onClick={() => dispatch({ type: Actions.AddRedaction })}
-            >
-              Add Redaction
-            </button>
-            <ExportVideoButton videoRef={videoRef} />
-          </div>
+          <Video />
         </Show>
       </div>
     </div>

--- a/src/renderer/src/context/useVideoData.ts
+++ b/src/renderer/src/context/useVideoData.ts
@@ -1,10 +1,11 @@
-import { useContext } from "solid-js"
-import { VideoContext } from "./provider"
+import { useContext } from 'solid-js';
+import { VideoContext } from './provider';
+import { VideoAction, VideoState } from '@renderer/store';
 
-export const useVideoData = () => {
-  const store = useContext(VideoContext)
+export const useVideoData = (): [VideoState, (action: VideoAction) => void] => {
+  const store = useContext(VideoContext);
   if (!store) {
-    throw new Error("useVideoData must be used within a VideoProvider")
+    throw new Error('useVideoData must be used within a VideoProvider');
   }
-  return store
-}
+  return store;
+};


### PR DESCRIPTION
When resizing the application window, the video container can resize. This will cause the redactions to shift around. We want to make it so the redactions scale with the video container.

1. Use a solid primitive hook: `createResizeObserver`
    In my initial implementation the hook was not working. I found it was because the app initializes without a video, so the `videoRef` was not defined. By separating the video logic into its own component we can assure that it is going to be defined `onMount` and correctly implement the hook.
2. Add more actions to the store to handle the resizing logic.